### PR TITLE
Add Support For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,102 +2,106 @@ name: Build
 
 on:
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   pull_request:
-    paths-ignore: ['*.md']
-    branches: [ master, main ]
+    paths-ignore: ["*.md"]
+    branches: [main]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-gcr-worker-analysis
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run static analysis
         run: composer analyse
   test:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.4, 8.0, 8.1 ]
+        php: [8.0, 8.1, 8.2]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-gcr-worker-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
-      - name: Run PHPUnit tests and generate code coverage
-        run: |
-          vendor/bin/phpunit
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-gcr-worker-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run PHPUnit tests and generate code coverage
-        run: |
-          vendor/bin/phpunit --coverage-clover=clover.xml
+        run: vendor/bin/phpunit --coverage-clover=clover.xml
       - name: Upload code coverage results
         run: bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,21 @@
         "source": "https://github.com/richan-fongdasen/laravel-gcr-worker"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/queue": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "kainxspirits/laravel-pubsub-queue": "^0.6|^0.7|^0.8"
+        "php": "^8.0",
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/queue": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "kainxspirits/laravel-pubsub-queue": "^0.6|^0.7|^0.8|^0.9"
     },
     "require-dev": {
         "ekino/phpstan-banned-code": "^1.0",
+        "larastan/larastan": "^1.0|^2.0",
         "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpmd/phpmd": "^2.11",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "phpunit/phpunit": "^9.5",
-        "sebastian/phpcpd": "^6.0"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "config": {
         "sort-packages": true
@@ -64,8 +63,7 @@
         "analyse": [
             "composer check-syntax",
             "composer phpstan-analysis",
-            "composer phpmd-analysis",
-            "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+            "composer phpmd-analysis"
         ],
         "check-syntax": [
             "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Laravel GCR Worker Test Suite">
       <directory suffix="Test.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
-
-![Build Status](https://github.com/richan-fongdasen/laravel-gcr-worker/workflows/Build/badge.svg?branch=master)
+[![Build](https://github.com/richan-fongdasen/laravel-gcr-worker/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/richan-fongdasen/laravel-gcr-worker/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/richan-fongdasen/laravel-gcr-worker/branch/master/graph/badge.svg)](https://codecov.io/gh/richan-fongdasen/laravel-gcr-worker)
 [![Total Downloads](https://poser.pugx.org/richan-fongdasen/laravel-gcr-worker/d/total.svg)](https://packagist.org/packages/richan-fongdasen/laravel-gcr-worker)
 [![Latest Stable Version](https://poser.pugx.org/richan-fongdasen/laravel-gcr-worker/v/stable.svg)](https://packagist.org/packages/richan-fongdasen/laravel-gcr-worker)
@@ -32,9 +31,9 @@ $ composer require richan-fongdasen/laravel-gcr-worker
 ### Laravel version compatibility
 
 | Laravel version | Package version |
-|:----------------|:----------------|
+| :-------------- | :-------------- |
 | 5.7 - 8.x       | 1.0 - 1.3       |
-| 8.x - 10.x      | ^1.5            |
+| 8.x - 11.x      | ^1.6            |
 
 ## Configuration
 

--- a/tests/Feature/PubSubEventHandlingTest.php
+++ b/tests/Feature/PubSubEventHandlingTest.php
@@ -12,7 +12,7 @@ class PubSubEventHandlingTest extends TestCase
     #[Test]
     public function it_will_return_403_on_unauthorized_pubsub_request()
     {
-        $data = json_decode(file_get_contents(dirname(__DIR__, 2) . '/dummies/message.json'), true);
+        $data = json_decode(file_get_contents(dirname(__DIR__, 2).'/dummies/message.json'), true);
 
         $this->postJson('/gcr-worker/pub-sub/event-handler', $data)
             ->assertStatus(403);
@@ -25,7 +25,7 @@ class PubSubEventHandlingTest extends TestCase
 
         config(['gcr-worker.allow_event_invocation' => true]);
 
-        $data = json_decode(file_get_contents(dirname(__DIR__, 2) . '/dummies/message.json'), true);
+        $data = json_decode(file_get_contents(dirname(__DIR__, 2).'/dummies/message.json'), true);
 
         self::assertNull(Cache::get('dummy-job-status'));
 

--- a/tests/Feature/PubSubEventHandlingTest.php
+++ b/tests/Feature/PubSubEventHandlingTest.php
@@ -3,28 +3,29 @@
 namespace RichanFongdasen\GCRWorker\Tests\Feature;
 
 use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\GCRWorker\Facade\GcrQueue;
 use RichanFongdasen\GCRWorker\Tests\TestCase;
 
 class PubSubEventHandlingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_will_return_403_on_unauthorized_pubsub_request()
     {
-        $data = json_decode(file_get_contents(dirname(__DIR__, 2).'/dummies/message.json'), true);
+        $data = json_decode(file_get_contents(dirname(__DIR__, 2) . '/dummies/message.json'), true);
 
         $this->postJson('/gcr-worker/pub-sub/event-handler', $data)
             ->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_pubsub_invocation_as_expected()
     {
         GcrQueue::fake();
 
         config(['gcr-worker.allow_event_invocation' => true]);
 
-        $data = json_decode(file_get_contents(dirname(__DIR__, 2).'/dummies/message.json'), true);
+        $data = json_decode(file_get_contents(dirname(__DIR__, 2) . '/dummies/message.json'), true);
 
         self::assertNull(Cache::get('dummy-job-status'));
 
@@ -32,8 +33,8 @@ class PubSubEventHandlingTest extends TestCase
             ->assertStatus(200)
             ->assertJsonFragment(['info' => 'The Pub/Sub queued job has completed.']);
 
-//        GcrQueue::assertAcknowledgedMessagesCount(1);
-//        GcrQueue::assertMessageHasAcknowledged('1777817206939726');
+        //        GcrQueue::assertAcknowledgedMessagesCount(1);
+        //        GcrQueue::assertMessageHasAcknowledged('1777817206939726');
 
         self::assertEquals('completed', Cache::get('dummy-job-status'));
     }

--- a/tests/Feature/ScheduledJobHandlingTest.php
+++ b/tests/Feature/ScheduledJobHandlingTest.php
@@ -2,18 +2,19 @@
 
 namespace RichanFongdasen\GCRWorker\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\GCRWorker\Tests\TestCase;
 
 class ScheduledJobHandlingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_will_return_403_on_unauthorized_scheduled_job_request()
     {
         $this->getJson('/gcr-worker/run-scheduled-job')
             ->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_scheduled_job_invocation_as_expected()
     {
         config(['gcr-worker.allow_event_invocation' => true]);


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update Github actions workflow's configuration
* Update readme